### PR TITLE
fix bug in final total cluster locations

### DIFF
--- a/R/cluster_functions.R
+++ b/R/cluster_functions.R
@@ -913,6 +913,14 @@ add_location_counts <- function(cluster_list, cases) {
     )
   }
 
+  # merge the actual cluster center observed counts
+  cluster_alert_table[, count_sum:=NULL]
+  cluster_alert_table <- merge(
+    cluster_alert_table,
+    cluster_location_counts[target==location, .(count_sum = count, target)],
+    by.x = "target", by.y="target"
+  )
+
   # clean the cluster alert_table
 
   clusters <- list(


### PR DESCRIPTION
added a quick fix to ensure the cluster center total observed actually reflects the number in the test period over the cluster dates for that center location